### PR TITLE
phpのイメージ作成

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -1,1 +1,9 @@
-FROM php:8.1-fpm-buster
+## PHPの公式リリースに含まれるDebianベースのimage
+## busterのDebian10は使わずに検証
+FROM php:8.2-fpm
+
+## appディレクトリの作成
+RUN mkdir /app
+
+## 起動時にappディレクトリを選択
+WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,9 @@ services:
   app:
     container_name: ecs-app
     ports:
-      - "${FASTCGI_PORT:-9000}:9000"
+      - "9000:9000" ## php-fpmはデフォルトで9000番ポート
     build:
       context: .
-      dockerfile: .docker/php/Dockerfile
-    depends_on:
-      - mysql
-      - redis
+      dockerfile: .docker/php/Dockerfile # docker/php/Dockerfileのなかの内容でimageを作成
     volumes:
-      - ./:/app
-      - .docker/php/php.ini:/usr/local/etc/php/php.ini
+      - ./:/app  # カレントディレクトリの内容をphpのimageの中にマウント(コピー)


### PR DESCRIPTION
## 学んだこと

DockerfileでWORKDIRを作成せずに、コンテナの中に入るとこんな感じ

```
root@c353fcd278e2:/var/www/html#
```

ただし、マウントさえできていれば、下記のように、探せば見つかる。
あくまでも作業しやすいようにWORKDIRを書いてる

```
root@c353fcd278e2:/var/www/html# cd ..
root@c353fcd278e2:/var/www# cd ..
root@c353fcd278e2:/var# cd ..
root@c353fcd278e2:/# ls
app  bin  boot  dev  etc  home  lib  lib32  lib64  libx32  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
root@c353fcd278e2:/# cd app
root@c353fcd278e2:/app# 
```


volumesでマウントしなければ、下記のように中身が空になる
```
root@651399c038ba:/app# ls
root@651399c038ba:/app# 
```


phpのimageのportを変える方法
マウントされたimageを見るとこんな感じで9000番のportが指定されてる
変更するには、/usr/local/etc/php-fpm.d/zz-docker.confに対してlocalファイルをマウントすれば可能

```
root@c353fcd278e2:/usr/local/etc/php-fpm.d# cat zz-docker.conf
[global]
daemonize = no

[www]
listen = 9000

```