### PR TITLE
phpのイメージのphpの設定

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -2,6 +2,9 @@
 ## busterのDebian10は使わずに検証
 FROM php:8.2-fpm
 
+## オペキャッシュをインストール
+RUN docker-php-ext-install opcache
+
 ## appディレクトリの作成
 RUN mkdir /app
 

--- a/.docker/php/php.ini
+++ b/.docker/php/php.ini
@@ -1,0 +1,30 @@
+## ファイルサイズなどは使用しないのでデフォルト
+## メモリーは無制限
+memory_limit = -1
+default_charset = UTF-8
+
+## ログの出力先
+[log]
+error_log = /var/log/php/php-error.log
+log_errors = on
+error_reporting = E_ALL
+
+## セッションの設定
+[Session]
+## HTTPS上でのみクッキー送信許容
+session.cookie_secure=1
+
+## JavaScriptからのセッションクッキーのアクセスを禁止
+session.cookie_httponly=1
+
+[Date]
+date.timezone = Asia/Tokyo
+
+[mbstring]
+mbstring.language = Japanese
+
+[xdebug]
+## インストールしてないため不要
+
+[opcache]
+opcache.enable = 0 ## ソースコードのキャッシュ、最適化して高速化できる　localではキャッシュされると困るのでOFF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,5 @@ services:
       dockerfile: .docker/php/Dockerfile # docker/php/Dockerfileのなかの内容でimageを作成
     volumes:
       - ./:/app  # カレントディレクトリの内容をphpのimageの中にマウント(コピー)
+      - .docker/php/php.ini:/usr/local/etc/php/php.ini
+


### PR DESCRIPTION
## 学んだこと

docker imageのphpの設定を変えるにはphp.iniを変更する必要がある。
下記に変更できる公式のリストあり

https://www.php.net/manual/ja/ini.list.php

 error-logに関して、下記のようにintファイルに記載してるが、実際CLIでエラー出た時ログが書き込まれてなかったので、再度確認する

```
[log]
error_log = /var/log/php/php-error.log
log_errors = on
error_reporting = E_ALL
```

```
root@2c4376994d72://# cd /var/log/                 
root@2c4376994d72:/var/log# ls
alternatives.log  apt  btmp  dpkg.log  faillog  lastlog  wtmp

```

下記のセキュリティに関する項目は設定した方が良い気がした。

```
## セッションの設定
[Session]
## HTTPS上でのみクッキー送信許容
session.cookie_secure=1

## JavaScriptからのセッションクッキーのアクセスを禁止
session.cookie_httponly=1

```

本番環境の時はオペキャッシュを有効にした方が処理が早くなるみたい。
下記で入ってるか見ることができる。推奨の設定は[こちら](https://www.php.net/manual/ja/opcache.installation.php)

▼インストール前
```
root@95dd916783f3:/app# php -v
PHP 8.2.11 (cli) (built: Oct 12 2023 04:15:27) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.11, Copyright (c) Zend Technologies
```

▼インストール後
```
root@95dd916783f3:/app# php -v
PHP 8.2.11 (cli) (built: Oct 12 2023 04:15:27) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.2.11, Copyright (c) Zend Technologies
    with Zend OPcache v8.2.11, Copyright (c), by Zend Technologies
```

```
[opcache]
opcache.enable = 0 ## ソースコードのキャッシュ、最適化して高速化できる　localではキャッシュされると困るのでOFF
```