### PR TITLE
nginxのimageを作成

### DIFF
--- a/.docker/nginx/Dockerfile
+++ b/.docker/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:latest
+
+RUN apt update && apt install -y vim ## viを使いたいのでインストール

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,12 @@ services:
     volumes:
       - ./:/app  # カレントディレクトリの内容をphpのimageの中にマウント(コピー)
       - .docker/php/php.ini:/usr/local/etc/php/php.ini
-
+  nginx:
+    container_name: ecs-nginx
+    ports:
+      - "80:80" ## ホスト名だけでアクセスできるようにしたいので、httpの80ポート、host側を変える場合は他の変更箇所なし
+    build: ## コンテナ側のportを変えるときは、default.confのlistenの変更必要、ホスト側が変更するとlocalhost:portでアクセス可能
+      context: .
+      dockerfile: .docker/nginx/Dockerfile  #dockerfile内でimageをbuild
+    depends_on:
+      - app


### PR DESCRIPTION
## 学んだこと

```.docker

  nginx:
    container_name: ecs-nginx
    ports:
      - "80:80" ## ホスト名だけでアクセスできるようにしたいので、httpの80ポート、host側を変える場合は他の変更箇所なし
    build: ## コンテナ側のportを変えるときは、default.confのlistenの変更必要、ホスト側が変更するとlocalhost:portでアクセス可能
      context: .
      dockerfile: .docker/nginx/Dockerfile  #dockerfile内でimageをbuild
    depends_on:
      - app
```
depends_onは依存関係を表し、コンテナ起動時、停止時の順番も変わる

起動時：app → nginx
停止時：nginx → app



```
server {
    listen       80;    ## ここでホスト側のportを設定する
    listen  [::]:80;　## ここでホスト側のportを設定する
    server_name  localhost;

    #access_log  /var/log/nginx/host.access.log  main;

    location / {
        root   /usr/share/nginx/html;
        index  index.html index.htm;
    }

```

nginxの設定ファイルは下記の2つが存在する

- etc/nginx/nginx.conf
- etc/nginx/conf.d/default.conf


```
etc/nginx/nginx.conf
```
nginxの大元の設定ファイル、ここに他のファイルをincludeしてる

```
etc/nginx/conf.d/default.conf
```
nginxのserverディレクティブの内容を書いたファイル
