### PR TITLE
mysqlのイメージ作成

### DIFF
--- a/.docker/mysql/Dockerfile
+++ b/.docker/mysql/Dockerfile
@@ -1,0 +1,1 @@
+FROM mysql:8.0

--- a/.docker/nginx/default.conf
+++ b/.docker/nginx/default.conf
@@ -1,0 +1,21 @@
+server {
+  #localhostでアクセスしたいのでそのまま　80以外を変更すると、ymlのコンテ側も変える必要あり
+  listen 80;
+    #appコンテナのlaravelの/app/public/index.phpの存在するディレクトリを指定（laravelがindex.phpを最初に読み込むため）
+    root /app/public;
+    #app/public/の中でどれを読み込むか指定
+    index index.php;
+
+     location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+  location ~ \.php$ {
+    fastcgi_split_path_info ^(.+\.php)(/.+)$;
+    fastcgi_pass app:9000;
+    fastcgi_index index.php;
+    include fastcgi_params;
+      fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+      fastcgi_param PATH_INFO $fastcgi_path_info;
+  }
+ }

--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -5,8 +5,15 @@ FROM php:8.2-fpm
 ## オペキャッシュをインストール
 RUN docker-php-ext-install opcache
 
+## composer install際に、gitをインストールしないとエラーが出るためインストール
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
 ## appディレクトリの作成
 RUN mkdir /app
 
 ## 起動時にappディレクトリを選択
 WORKDIR /app
+
+## composer installできるようにDocker に Composer をインストール
+## composer installがないとlaravelのwelcomeページ表示できない
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+/.docker/mysql/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,14 +14,16 @@ services:
         - mysql
 
   nginx:
-    container_name: ecs-nginx
-    ports:
-      - "80:80" ## ホスト名だけでアクセスできるようにしたいので、httpの80ポート、host側を変える場合は他の変更箇所なし
-    build: ## コンテナ側のportを変えるときは、default.confのlistenの変更必要、ホスト側が変更するとlocalhost:portでアクセス可能
-      context: .
-      dockerfile: .docker/nginx/Dockerfile  #dockerfile内でimageをbuild
-    depends_on:
-      - app
+      container_name: ecs-nginx
+      ports:
+        - "80:80" ## ホスト名だけでアクセスできるようにしたいので、httpの80ポート、host側を変える場合は他の変更箇所なし
+      build: ## コンテナ側のportを変えるときは、default.confのlistenの変更必要、ホスト側が変更するとlocalhost:portでアクセス可能
+        context: .
+        dockerfile: .docker/nginx/Dockerfile  #dockerfile内でimageをbuild
+      volumes:
+        - .docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+      depends_on:
+        - app
 
   mysql:
     container_name: ecs-mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,10 +31,10 @@ services:
         - "3306:3306"
     build:
         context: .
-        dockerfile: .docker/mysql/Dockerfile
+        dockerfile: .docker/mysql/Dockerfile # docker/mysql/Dockerfileのなかの内容でimageを作成
     environment:
-        MYSQL_ROOT_PASSWORD: password
-        MYSQL_USER: user
-        MYSQL_PASSWORD: password
+        MYSQL_ROOT_PASSWORD: password #rootユーザーのパスワード
+        MYSQL_USER: user #userのユーザー名
+        MYSQL_PASSWORD: password #userのパスワード
     volumes:
         - .docker/mysql/db/:/var/lib/mysql/ #永続化させるために記述、mysqlサーバ側fileなどをホストにマウントさせる

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
     volumes:
       - ./:/app  # カレントディレクトリの内容をphpのimageの中にマウント(コピー)
       - .docker/php/php.ini:/usr/local/etc/php/php.ini
+    depends_on:
+        - mysql
+
   nginx:
     container_name: ecs-nginx
     ports:
@@ -19,3 +22,17 @@ services:
       dockerfile: .docker/nginx/Dockerfile  #dockerfile内でimageをbuild
     depends_on:
       - app
+
+  mysql:
+    container_name: ecs-mysql
+    ports:
+        - "3306:3306"
+    build:
+        context: .
+        dockerfile: .docker/mysql/Dockerfile
+    environment:
+        MYSQL_ROOT_PASSWORD: password
+        MYSQL_USER: user
+        MYSQL_PASSWORD: password
+    volumes:
+        - .docker/mysql/db/:/var/lib/mysql/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,4 +37,4 @@ services:
         MYSQL_USER: user
         MYSQL_PASSWORD: password
     volumes:
-        - .docker/mysql/db/:/var/lib/mysql/
+        - .docker/mysql/db/:/var/lib/mysql/ #永続化させるために記述、mysqlサーバ側fileなどをホストにマウントさせる


### PR DESCRIPTION
## 学んだこと
- 永続化について
volumesに書いた内容が、コンテナ側に反映されると思っていたが、コンテナ内で削除したりするとホスト側にも反映される。これがdockerのvolumes機能

```.yml
  mysql:
    container_name: ecs-mysql
    ports:
        - "3306:3306"
    build:
        context: .
        dockerfile: .docker/mysql/Dockerfile # docker/mysql/Dockerfileのなかの内容でimageを作成
    environment:
        MYSQL_ROOT_PASSWORD: password #rootユーザーのパスワード
        MYSQL_USER: user #userのユーザー名
        MYSQL_PASSWORD: password #userのパスワード
    volumes:
        - .docker/mysql/db/:/var/lib/mysql/ #永続化させるために記述、mysqlサーバ側fileなどをホストにマウントさせる

```
