### PR TITLE
mysqlの設定の変更

### DIFF
--- a/.docker/mysql/my.cnf
+++ b/.docker/mysql/my.cnf
@@ -1,5 +1,4 @@
 [mysqld]
-/* スロークエリーの設定 */
 slow_query_log=ON
 long_query_time = 1
 slow_query_log_file = /tmp/mysql-slow.log

--- a/.docker/mysql/my.cnf
+++ b/.docker/mysql/my.cnf
@@ -1,0 +1,5 @@
+[mysqld]
+/* スロークエリーの設定 */
+slow_query_log=ON
+long_query_time = 1
+slow_query_log_file = /tmp/mysql-slow.log

--- a/.docker/mysql/my.cnf
+++ b/.docker/mysql/my.cnf
@@ -2,3 +2,8 @@
 slow_query_log=ON
 long_query_time = 1
 slow_query_log_file = /tmp/mysql-slow.log
+character-set-server=utf8mb4
+collation-server=utf8mb4_general_ci
+
+[client]
+default-character-set=utf8mb4

--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -8,6 +8,8 @@ RUN docker-php-ext-install opcache
 ## composer install際に、gitをインストールしないとエラーが出るためインストール
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
+RUN docker-php-ext-install pdo pdo_mysql
+
 ## appディレクトリの作成
 RUN mkdir /app
 

--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -8,6 +8,7 @@ RUN docker-php-ext-install opcache
 ## composer install際に、gitをインストールしないとエラーが出るためインストール
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
+## mysqlを操作できるライブラリ
 RUN docker-php-ext-install pdo pdo_mysql
 
 ## appディレクトリの作成

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
         context: .
         dockerfile: .docker/mysql/Dockerfile # docker/mysql/Dockerfileのなかの内容でimageを作成
     environment:
+        MYSQL_DATABASE: laravel
         MYSQL_ROOT_PASSWORD: password #rootユーザーのパスワード
         MYSQL_USER: user #userのユーザー名
         MYSQL_PASSWORD: password #userのパスワード

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,3 +38,4 @@ services:
         MYSQL_PASSWORD: password #userのパスワード
     volumes:
         - .docker/mysql/db/:/var/lib/mysql/ #永続化させるために記述、mysqlサーバ側fileなどをホストにマウントさせる
+        - .docker/mysql/my.cnf:/etc/mysql/conf.d/my.conf #mysqlの設定を記述


### PR DESCRIPTION
## 学んだこと

mysqlの設定は/etc/my.confが存在する。
しかし下記の最後のところに別のディレクトリから内容をインクルードすることも可能

```
# For advice on how to change settings please see
# http://dev.mysql.com/doc/refman/8.0/en/server-configuration-defaults.html

[mysqld]
#
# Remove leading # and set to the amount of RAM for the most important data
# cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
# innodb_buffer_pool_size = 128M
#
# Remove leading # to turn on a very important data integrity option: logging
# changes to the binary log between backups.
# log_bin
#
# Remove leading # to set options mainly useful for reporting servers.
# The server defaults are faster for transactions and fast SELECTs.
# Adjust sizes as needed, experiment to find the optimal values.
# join_buffer_size = 128M
# sort_buffer_size = 2M
# read_rnd_buffer_size = 2M

# Remove leading # to revert to previous value for default_authentication_plugin,
# this will increase compatibility with older clients. For background, see:
# https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
# default-authentication-plugin=mysql_native_password
skip-host-cache
skip-name-resolve
datadir=/var/lib/mysql
socket=/var/run/mysqld/mysqld.sock
secure-file-priv=/var/lib/mysql-files
user=mysql

pid-file=/var/run/mysqld/mysqld.pid
[client]
socket=/var/run/mysqld/mysqld.sock

!includedir /etc/mysql/conf.d/     ## ここで別のmy.confを読み込みできる

```

追加で下記の設定がおすすめ

```
etc/mysql/conf.d/my.conf

[mysqld]
// スロークエリーのログを出力
slow_query_log=ON
long_query_time = 1
slow_query_log_file = /tmp/mysql-slow.log

// 文字コードで絵文字もOK
character-set-server=utf8mb4
collation-server=utf8mb4_general_ci

[client]
default-character-set=utf8mb4
```